### PR TITLE
Update actions/checkout from v4.1.1 to v6.0.2

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Test
         run: make test ssl=0.9.0 config=debug
       - name: Send alert on failure

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -24,7 +24,7 @@ jobs:
       image: ghcr.io/ponylang/library-documentation-action-v2:release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Generate documentation
         run: /entrypoint.py
         env:

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Check workflow files
         uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
         with:

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Lint codebase
         uses: docker://github/super-linter:v3.8.3
         env:
@@ -29,7 +29,7 @@ jobs:
     name: Verify CHANGELOG is valid
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Verify CHANGELOG
         uses: docker://ghcr.io/ponylang/changelog-tool:release
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,6 @@ jobs:
     container:
       image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Test
         run: make test ssl=0.9.0 config=debug

--- a/.github/workflows/prepare-for-a-release.yml
+++ b/.github/workflows/prepare-for-a-release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
       image: ghcr.io/ponylang/library-documentation-action-v2:release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
     needs:
       - generate-documentation
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Node 20 reaches EOL in April 2026 and GitHub will force Node 24 after June 2, 2026. v6 already uses Node 24 natively.