### PR TITLE
Update zulip/github-actions-zulip/send-message to v2.0.1

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -20,7 +20,7 @@ jobs:
         run: make test ssl=0.9.0 config=debug
       - name: Send alert on failure
         if: ${{ failure() }}
-        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
         with:
           api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
           email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}

--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Send alert on failure
         if: ${{ failure() }}
-        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
         with:
           api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
           email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -29,7 +29,7 @@ jobs:
           API_CREDENTIALS: ${{ secrets.GITHUB_TOKEN }}
       - name: Send alert on failure
         if: ${{ failure() }}
-        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
         with:
           api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
           email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}


### PR DESCRIPTION
Bump the pinned SHA for `zulip/github-actions-zulip/send-message` to v2.0.1 (`bd8ec52`). The action's inputs are unchanged from the previously pinned version; v2 only updates the action's internal Node runtime (node20 → node24).