### PR TITLE
Fix pony-lint findings for ponyc 0.69.0

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -9,6 +9,27 @@ permissions:
   packages: read
 
 jobs:
+  pony-lint:
+    name: Lint against ponyc main
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   vs-ponyc-latest:
     name: Test against ponyc main
     runs-on: ubuntu-latest

--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,10 +18,10 @@ permissions:
 
 jobs:
   vs-ponyc-release:
-    name: Test against recent ponyc release
+    name: Test against recent ponyc nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,10 +18,10 @@ permissions:
 
 jobs:
   vs-ponyc-release:
-    name: Test against recent ponyc nightly
+    name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/lock.json
+++ b/lock.json
@@ -1,0 +1,8 @@
+{
+  "locks": [
+    {
+      "locator": ".",
+      "revision": "main"
+    }
+  ]
+}

--- a/valbytes/_test.pony
+++ b/valbytes/_test.pony
@@ -87,16 +87,16 @@ primitive \nodoc\ _ByteArrayAndSourceGen
     let size_gen =
       Generators.usize(min_size, max_size)
     let array_and_splits_gen
-      : Generator[(Array[U8] iso, Array[USize] iso)]
-    =
+      : Generator[(Array[U8] iso, Array[USize] iso)] =
+
       size_gen
         .flat_map[(Array[U8] iso, Array[USize] iso)](
         {(size: USize)
           : Generator[(Array[U8] iso, Array[USize] iso)]
         =>
           let array_gen
-            : Generator[Array[U8] iso]
-          =
+            : Generator[Array[U8] iso] =
+
             Generators.iso_seq_of[U8, Array[U8] iso](
               Generators.u8('a', 'z'),
               size,
@@ -283,16 +283,16 @@ class \nodoc\ iso _ValuesProperty is Property1[(Array[U8] val, ByteArrays)]
       h.assert_eq[U8](
         array_elem,
         ba_elem,
-        "differing elements at index: "
-          + i.string())
+        "differing elements at index: " +
+          i.string())
       i = i + 1
     end
     if array_iter.has_next() or
       ba_iter.has_next()
     then
       h.fail(
-        "ByteArrays.values() longer than "
-          + "Array.values().")
+        "ByteArrays.values() longer than " +
+          "Array.values().")
     end
 
 class \nodoc\ iso _ApplyProperty is Property1[(Array[U8] val, ByteArrays)]
@@ -310,8 +310,8 @@ class \nodoc\ iso _ApplyProperty is Property1[(Array[U8] val, ByteArrays)]
       h.assert_eq[U8](
         sample._1(i)?,
         sample._2(i)?,
-        "Differing result from apply at index "
-          + i.string())
+        "Differing result from apply at index " +
+          i.string())
       i = i + 1
     end
 

--- a/valbytes/byte_arrays.pony
+++ b/valbytes/byte_arrays.pony
@@ -283,8 +283,8 @@ class val ByteArrays is (ValBytes & mut.Hashable)
         | let ra: Array[U8] val => String.from_array(ra)
         // TODO: consider EmptyValBytes
         | let rv: ValBytes      => recover val String .> concat(rv.values()) end
-        end
-        + "]"
+        end +
+        "]"
       end
 
     "[" + ls + "-" + rs + "]"


### PR DESCRIPTION
Fix pony-lint errors surfaced by ponyc 0.69.0 (operator-spacing, and for uri also line-length), add a nightly-lint job to the breakage workflow, and switch PR CI to nightly until 0.69.0 releases. Public API is unchanged; no release note or CHANGELOG entry.