### PR TITLE
Add lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tags
 .deps/*
 /_corral/
 /_repos/
+lock.json

--- a/lock.json
+++ b/lock.json
@@ -1,8 +1,0 @@
-{
-  "locks": [
-    {
-      "locator": ".",
-      "revision": "main"
-    }
-  ]
-}


### PR DESCRIPTION
`lock.json` is generated by `corral fetch` and should not be checked in.