### PR TITLE
Switch CI from nightly to release

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test


### PR DESCRIPTION
Switch container image tags from `:nightly` to `:release` in pr.yml and pony-lint.yml.